### PR TITLE
Port to SDL2 & Add additional audio strem encodings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,417 @@
+# Cmake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+CMakeSettings.json
+
+## Ignore Visual Studio temporary files, build results, and
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Mono auto generated files
+mono_crash.*
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs
+
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUnit
+*.VisualState.xml
+TestResult.xml
+nunit-*.xml
+
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+# Benchmark Results
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# StyleCop
+StyleCopReport.xml
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.iobj
+*.pch
+*.pdb
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+# but not Directory.Build.rsp, as it configures directory-level build defaults
+!Directory.Build.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*_wpftmp.csproj
+*.log
+*.tlog
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Chutzpah Test files
+_Chutzpah*
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# Visual Studio Trace Files
+*.e2e
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# TeamCity is a build add-in
+_TeamCity*
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# AxoCover is a Code Coverage Tool
+.axoCover/*
+!.axoCover/settings.json
+
+# Coverlet is a free, cross platform Code Coverage Tool
+coverage*.json
+coverage*.xml
+coverage*.info
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+
+# MightyMoose
+*.mm.*
+AutoTest.Net/
+
+# Web workbench (sass)
+.sass-cache/
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
+
+# NuGet Packages
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!?*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*~
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+# (https://github.com/github/gitignore/pull/2483#issue-259490424)
+#*.snk
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+*.rptproj.rsuser
+*- [Bb]ackup.rdl
+*- [Bb]ackup ([0-9]).rdl
+*- [Bb]ackup ([0-9][0-9]).rdl
+
+# Microsoft Fakes
+FakesAssemblies/
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+node_modules/
+
+# Visual Studio 6 build log
+*.plg
+
+# Visual Studio 6 workspace options file
+*.opt
+
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+*.vbw
+
+# Visual Studio 6 auto-generated project file (contains which files were open etc.)
+*.vbp
+
+# Visual Studio 6 workspace and project file (working project files containing files to include in project)
+*.dsw
+*.dsp
+
+# Visual Studio 6 technical files
+*.ncb
+*.aps
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Paket dependency manager
+.paket/paket.exe
+paket-files/
+
+# FAKE - F# Make
+.fake/
+
+# CodeRush personal settings
+.cr/personal
+
+# Python Tools for Visual Studio (PTVS)
+__pycache__/
+*.pyc
+
+# Cake - Uncomment if you are using it
+# tools/**
+# !tools/packages.config
+
+# Tabs Studio
+*.tss
+
+# Telerik's JustMock configuration file
+*.jmconfig
+
+# BizTalk build output
+*.btp.cs
+*.btm.cs
+*.odx.cs
+*.xsd.cs
+
+# OpenCover UI analysis results
+OpenCover/
+
+# Azure Stream Analytics local run output
+ASALocalRun/
+
+# MSBuild Binary and Structured Log
+*.binlog
+
+# NVidia Nsight GPU debugger configuration file
+*.nvuser
+
+# MFractors (Xamarin productivity tool) working folder
+.mfractor/
+
+# Local History for Visual Studio
+.localhistory/
+
+# Visual Studio History (VSHistory) files
+.vshistory/
+
+# BeatPulse healthcheck temp database
+healthchecksdb
+
+# Backup folder for Package Reference Convert tool in Visual Studio 2017
+MigrationBackup/
+
+# Ionide (cross platform F# VS Code tools) working folder
+.ionide/
+
+# Fody - auto-generated XML schema
+FodyWeavers.xsd
+
+# VS Code files for those working on multiple tools
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+# Windows Installer files from build outputs
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# JetBrains Rider
+*.sln.iml
+
+# Build dirs
+out/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.14)
+
+# Project name and version
+project(smushplay LANGUAGES CXX)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Locate all .cpp and .h files in the root folder
+file(GLOB SOURCE_FILES "${CMAKE_SOURCE_DIR}/*.cpp" "${CMAKE_SOURCE_DIR}/*.h")
+
+# Add the executable target
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+
+# Find SDL2
+find_package(SDL2 REQUIRED)
+
+# Find ZLib
+find_package(ZLIB REQUIRED)
+
+# Include SDL2 headers and link libraries
+target_include_directories(${PROJECT_NAME} PRIVATE ${SDL2_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${SDL2_LIBRARIES} ZLIB::ZLIB)
+
+message(STATUS "SDL2 include directories: ${SDL2_INCLUDE_DIRS}")
+message(STATUS "SDL2 libraries: ${SDL2_LIBRARIES}")
+message(STATUS "zlib include directories: ${ZLIB_INCLUDE_DIRS}")
+message(STATUS "zlib libraries: ${ZLIB_LIBRARIES}")

--- a/audioman.h
+++ b/audioman.h
@@ -85,7 +85,8 @@ private:
 
 		bool endOfStream() const;
 		bool endOfData() const;
-		void mix(int16 *samples, uint length);
+		void mixInt16(int16 *samples, uint length);
+		void mix(SDL_AudioFormat format, void *samples, uint length);
 
 		void setVolume(byte volume);
 		byte getVolume() const { return _volume; }

--- a/graphicsman.h
+++ b/graphicsman.h
@@ -25,21 +25,27 @@
 
 #include "types.h"
 
-struct SDL_Surface;
+struct SDL_Window;
+struct SDL_Renderer;
+struct SDL_Texture;
 
 class GraphicsManager {
 public:
-	GraphicsManager();
+	GraphicsManager() = default;
 	~GraphicsManager();
-
-	bool init(uint width, uint height, bool highColor);
+	bool init(SDL_Window *window, uint width, uint height, bool highColor);
 	void blit(const byte *ptr, uint x, uint y, uint width, uint height, uint pitch);
 	void update();
 	void setPalette(const byte *ptr, uint start, uint count);
 
 private:
-	SDL_Surface *_mainScreen;
-	SDL_Surface *_workingScreen;
+	void convertIndexToRGBA(uint32_t *rgbaData, const byte *paletteData, int width, int height) const;
+	SDL_Renderer *_renderer = nullptr;
+	SDL_Texture *_texture   = nullptr;
+	SDL_Palette *_palette   = nullptr;
+	int _width  = 0;
+	int _height = 0;
+	bool _isHighColor = false;
 };
 
 #endif

--- a/smushplay.cpp
+++ b/smushplay.cpp
@@ -27,16 +27,6 @@
 #include "graphicsman.h"
 #include "smushvideo.h"
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-
-int __stdcall WinMain(HINSTANCE /*hInst*/, HINSTANCE /*hPrevInst*/,  LPSTR /*lpCmdLine*/, int /*iShowCmd*/) {
-	SDL_SetModuleHandle(GetModuleHandle(0));
-	return main(__argc, __argv);
-}
-#endif
-
 void printUsage(const char *appName) {
 	printf("Usage: %s <video>\n", appName);
 }
@@ -50,12 +40,12 @@ int main(int argc, char **argv) {
 	printf("Based on ScummVM and ResidualVM's SMUSH player\n");
 	printf("See COPYING for the license\n\n");
 
-	if (argc < 2) {
+	if ( argc < 2 ) {
 		printUsage(argv[0]);
 		return 0;
 	}
 
-	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0) {
+	if ( SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0 ) {
 		fprintf(stderr, "Failed to initialize SDL\n");
 		return 1;
 	}
@@ -64,28 +54,33 @@ int main(int argc, char **argv) {
 
 	// Initialize audio here
 	AudioManager audio;
-	if (!audio.init()) {
+	if ( !audio.init() ) {
 		fprintf(stderr, "Failed to initialize SDL audio\n");
 		return 1;
 	}
 
 	SMUSHVideo video(audio);
-	if (!video.load(argv[1])) {
+	if ( !video.load(argv[1]) ) {
 		fprintf(stderr, "Failed to play file '%s'\n", argv[1]);
 		return 1;
 	}
 
-	GraphicsManager gfx;
-	if (!gfx.init(video.getWidth(), video.getHeight(), video.isHighColor())) {
+	SDL_Window *window = SDL_CreateWindow("smushplay", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, video.getWidth(), video.getHeight(), SDL_WINDOW_SHOWN);
+	if ( !window ) {
 		fprintf(stderr, "Failed to initialize SDL screen\n");
 		return 1;
 	}
 
-	// Add our fun title
-	SDL_WM_SetCaption("smushplay", "smushplay");
+	GraphicsManager gfx;
+	if ( !gfx.init(window, video.getWidth(), video.getHeight(), video.isHighColor()) ) {
+		fprintf(stderr, "Failed to initialize SDL screen\n");
+		SDL_DestroyWindow(window);
+		return 1;
+	}
 
 	// Finally, play the damned thing
 	video.play(gfx);
 
+	SDL_DestroyWindow(window);
 	return 0;
 }


### PR DESCRIPTION
This PR introduces several significant updates and improvements:

### Changes
- Ported to SDL2:
        Updated the project to use SDL2 for graphics and audio.
        Added scaling of video to fit window size.

- Added audio encoding support:
        Implemented encoding of 16-bit audio to SDL audio streams.
        Supports AUDIO_F32SYS (float32) and AUDIO_S32SYS (int32) formats for audio stream encoding.

- Added CMake project setup:
        Introduced a CMakeLists.txt file for easier project configuration and building.
        Automatically includes all .cpp and .h files from the root directory.
        Added dependency management for SDL2 and zlib.

### Testing

The updates were tested on several videos from following games:

 - Indiana Jones and the Infernal Machine
 - Star Wars: Mysteries of the Sith (MOTS)
 - Grim Fandango
 - Star Wars: Droid Works

### Known Issues
 - MOTS Intro Video:
        The time location description (e.g., "A Long Time Ago...") does not fade in properly.

- Droid Works Videos:
        Audio plays too fast, resulting in a high-pitched sound.
        Video playback also appears to run faster than intended.